### PR TITLE
Permvirts

### DIFF
--- a/src_CAF/ORB_m.F90
+++ b/src_CAF/ORB_m.F90
@@ -106,7 +106,7 @@ contains
             free_face(2*dim) = .true.
             n_process_neighbour = 0
 
-            call ORB_bounds(thisImage, numImages, scale_k, gridind_ini, numImages, 1, imagerange_ini, ntotal+nvirt, &
+            call ORB_bounds(thisImage, numImages, scale_k, gridind_ini, numImages, 1, imagerange_ini, ntotal, &
                             dcell, mingridx_ini, maxgridx_ini, free_face)
 
             deallocate (pincell_ORB)
@@ -193,10 +193,12 @@ contains
       ! Counting local particles in each cell, and tracking non-zero cells
       n_nonzerocells = 0
       do i = 1, ntotal_loc
-         icell(1:dim) = int((parts(i)%x(:) - mingridx(:))/dcell) + 1
-         if (dim == 2) icell(3) = 1
-         icell(:) = icell(:) - cellmins(:, thisImage) + 1
-         pincell_ORB(icell(1), icell(2), icell(3)) = pincell_ORB(icell(1), icell(2), icell(3)) + 1
+         if (parts(i)%itype > 0) then
+            icell(1:dim) = int((parts(i)%x(:) - mingridx(:))/dcell) + 1
+            if (dim == 2) icell(3) = 1
+            icell(:) = icell(:) - cellmins(:, thisImage) + 1
+            pincell_ORB(icell(1), icell(2), icell(3)) = pincell_ORB(icell(1), icell(2), icell(3)) + 1
+         end if
       end do
 
       ! Getting each image to share it's min-max cell indices to other images

--- a/src_CAF/ORB_m.F90
+++ b/src_CAF/ORB_m.F90
@@ -32,7 +32,7 @@ contains
       type(time_tracking), intent(inout):: timings
       integer, codimension[*], intent(inout):: ntotal_loc, nhalo_loc, nvirt_loc
       integer:: tree_layers, maxnode, stepsSincePrevious, ngridx(3), i, j, k, d, imageRange_ini(2), gridind_ini(3, 2), &
-                old_ntv_loc
+                old_ntv_loc, ngridx_real(3)
       integer, codimension[*], save:: ntv_loc
       real(f):: mingridx_ini(3), maxgridx_ini(3), current_to_previous(dim, dim), box_ratio_current(dim, dim)
       logical:: free_face(2*dim)
@@ -59,13 +59,21 @@ contains
            (mod(stepsSincePrevious, ORBcheck2) == 0))) then
 
          ! checking if change in particles on current image is > 5%
-         if (ntotal_loc+nvirt_loc > prev_load + 0.05_f*real(ntotal+nvirt, kind=f)/real(thisImage, kind=f)) then
+         if (ntotal_loc > prev_load + 0.05_f*real(ntotal, kind=f)/real(thisImage, kind=f)) then
             repartition_mode = 2
          end if
 
          call co_max(repartition_mode)
 
          if ((repartition_mode > 1) .or. (itimestep .eq. 0)) then
+
+            if (thisImage == 1) then
+               write(*, '(A)') "_______________________________________________________________________________"
+               write(*, '(A)') "INFO: Image subdomain boundaries being updated"
+               write(*, '(6x, A, I0)') "Current timestep: ", itimestep
+               if (repartition_mode==2) write(*, '(6x, A)') "Repartition mode: Updating cut locations only"
+               if (repartition_mode==3) write(*, '(6x, A)') "Repartition mode: Updating cut orientations and locations"
+            end if
 
             partition_track%n_parts = partition_track%n_parts + 1
             if (itimestep /= 1) then
@@ -76,10 +84,10 @@ contains
 
             ! Creating particle-in-cell grid
             call particle_grid(thisImage, numImages, ntotal_loc+nvirt_loc, parts(1:ntotal_loc+nvirt_loc), ngridx, &
-               mingridx_ini, maxgridx_ini)
+               mingridx_ini, maxgridx_ini, ngridx_real)
 
             do d = 1, dim
-               box_ratio_current(:, d) = real(ngridx(d), kind=f)/real(ngridx(:), kind=f)
+               box_ratio_current(:, d) = real(ngridx_real(d), kind=f)/real(ngridx_real(:), kind=f)
             end do
 
             current_to_previous(:, :) = box_ratio_current(:, :)/box_ratio_previous(:, :)
@@ -147,37 +155,59 @@ contains
    end subroutine ORB
 
    !====================================================================================================================
-   subroutine particle_grid(thisImage, numImages, ntotal_loc, parts, ngridx, mingridx, maxgridx)
+   subroutine particle_grid(thisImage, numImages, ntotal_loc, parts, ngridx, mingridx, maxgridx, ngridx_real)
 
       implicit none
       integer, intent(in):: thisImage, numImages, ntotal_loc
       type(particles), intent(in):: parts(:)
-      integer, intent(out):: ngridx(3)
+      integer, intent(out):: ngridx(3), ngridx_real(3)
       real(f), intent(out):: mingridx(3), maxgridx(3)
-      real(f):: minx(3), maxx(3)
+      real(f):: minx(3), maxx(3), minx_real(3), maxx_real(3), mingridx_real(3), maxgridx_real(3)
       integer:: i, j, k, d, cellrange(3), icell(3), n_nonzerocells, n, otherImage
 
       ! Local max, min, in each direction ------------------------------------------------------------------------------
-      minx(1:dim) = parts(1)%x(1:dim)
-      maxx(1:dim) = parts(1)%x(1:dim)
-      do i = 2, ntotal_loc
+      minx(1:dim) = huge(1._f)
+      maxx(1:dim) = -huge(1._f)
+      minx_real(1:dim) = huge(1._f)
+      maxx_real(1:dim) = -huge(1._f)
+      do i = 1, ntotal_loc
          do d = 1, dim
-            if (parts(i)%x(d) > maxx(d)) maxx(d) = parts(i)%x(d)
-            if (parts(i)%x(d) < minx(d)) minx(d) = parts(i)%x(d)
+            maxx(d) = max(maxx(d), parts(i)%x(d))
+            minx(d) = min(minx(d), parts(i)%x(d))
+            if (parts(i)%itype > 0) then
+               maxx_real(d) = max(maxx_real(d), parts(i)%x(d))
+               minx_real(d) = min(minx_real(d), parts(i)%x(d))
+            end if
          end do
       end do
+
+      if (dim==2) then
+         minx(3) = 0._f
+         maxx(3) = 0._f
+         maxx_real(3) = 0._f
+         minx_real(3) = 0._f
+      end if
 
       ! Global max, min, in each direction -----------------------------------------------------------------------------
       mingridx(:) = minx(:)
       maxgridx(:) = maxx(:)
+      mingridx_real(:) = minx_real(:)
+      maxgridx_real(:) = maxx_real(:)
       call co_max(maxgridx)
       call co_min(mingridx)
+      call co_max(maxgridx_real)
+      call co_min(mingridx_real)
 
       ! Number of grid cells and adjusting max extent in each direction ------------------------------------------------
       mingridx(:) = mingridx(:) - 0.5_f*dcell
       maxgridx(:) = maxgridx(:) + 0.5_f*dcell
       ngridx(:) = int((maxgridx(:) - mingridx(:))/dcell) + 1
       maxgridx(:) = mingridx(:) + dcell*ngridx(:)
+
+      mingridx_real(:) = mingridx_real(:) - 0.5_f*dcell
+      maxgridx_real(:) = maxgridx_real(:) + 0.5_f*dcell
+      ngridx_real(:) = int((maxgridx_real(:) - mingridx_real(:))/dcell) + 1
+      maxgridx_real(:) = mingridx_real(:) + dcell*ngridx_real(:)
 
       ! Reducing search area by locating indices in which local particles are contained within
       cellmins(:, thisImage) = int((minx(:) - mingridx(:))/dcell) + 1

--- a/src_CAF/ORB_sr_m.f90
+++ b/src_CAF/ORB_sr_m.f90
@@ -248,7 +248,7 @@ contains
                      neighbours(j)%halo_pindex(neighbours(j)%nhalo_send) = i
                      neighbours(j)%HaloPackSend(neighbours(j)%nhalo_send) = parts(i)
                      neighbours(j)%HaloPackSend(neighbours(j)%nhalo_send)%itype = &
-                        neighbours(j)%HaloPackSend(neighbours(j)%nhalo_send)%itype + halotype
+                        neighbours(j)%HaloPackSend(neighbours(j)%nhalo_send)%itype + sign(halotype, parts(i)%itype)
                   end if
                end do
             end if

--- a/src_CAF/ORB_sr_m.f90
+++ b/src_CAF/ORB_sr_m.f90
@@ -153,18 +153,21 @@ contains
          ! Perform if necessary
          if (repartition_mode >= 2) then
 
-            if (thisImage == 1) write (*, '(A)') 'Checking whether diffusion is needed...'
+            if (thisImage == 1) write (*, '(6x, A)') 'Checking whether diffusion is needed...'
 
             call co_sum(ndiffuse)
 
             if (ndiffuse == 0) then
                diffuse = .false.
-               if (thisImage == 1) write (*, '(A)') 'No diffusion needed. Continuing...'
+               if (thisImage == 1) then
+                  write (*, '(6x, A)') 'No diffusion needed. Continuing...'
+                  write (*, '(A)') "_______________________________________________________________________________"
+               end if
             else
                if (thisImage .eq. 1) then
-                  write (*, '(A,I0)') 'Diffusion occuring... Current timestep:         ', itimestep
-                  write (*, '(A,I0)') '                      Current depth:            ', entrydepth
-                  write (*, '(A,I0)') '                      Particles to be diffused: ', ndiffuse
+                  write (*, '(6x, A,I0)') 'Diffusion occuring... Current timestep:         ', itimestep
+                  write (*, '(6x, A,I0)') '                      Current depth:            ', entrydepth
+                  write (*, '(6x, A,I0)') '                      Particles to be diffused: ', ndiffuse
                end if
 
                entrydepth = entrydepth + 1

--- a/src_CAF/flink_list_m.f90
+++ b/src_CAF/flink_list_m.f90
@@ -129,7 +129,8 @@ contains
       ! real-virtual
       ! real-halo
       ! halo-virtual - for deterimining boundary
-      if ((p_i%itype > 0 .or. p_j%itype > 0) .and. (p_i%itype < halotype .or. p_j%itype < halotype) ) then
+      ! if (.not.((p_i%itype<0 .and. p_j%itype<0) .or. (p_i%itype>halotype .and. p_j%itype>halotype))) then
+      if (p_i%itype>0 .or. p_j%itype>0) then
          dxiac(:) = p_i%x(:) - p_j%x(:)
          r = SQRT(SUM(dxiac*dxiac))
          if (r <= hsml*scale_k) then

--- a/src_CAF/input_m.f90
+++ b/src_CAF/input_m.f90
@@ -122,7 +122,7 @@ contains
       end if
       n_start = (thisImage - 1)*n_loc_i + 1
       n_done = n_start + n_loc_i - 1
-      write(*,*) thisImage, n_start, n_done
+      
       nvirt_loc = 0
       n = 0 ! counter used to track particle indices
 

--- a/src_CAF/main.F90
+++ b/src_CAF/main.F90
@@ -44,14 +44,12 @@ program SPH
    ! Generating initial geometry, performing initial partition, and assigning virtual particles
    call generate_real_part(thisImage, numImages, ntotal, ntotal_loc, parts)
 
-   call ORB(0, thisImage, numImages, scale_k, ntotal, ntotal_loc, nhalo_loc, nvirt_loc, parts, timings)
+   call generate_virt_part(thisImage, numImages, ntotal, ntotal_loc, nvirt, nvirt_loc, parts)
+   nhalo_loc = 0
+   call ORB(0, thisImage, numImages, scale_k, ntotal, ntotal_loc, nvirt, nvirt_loc, nhalo_loc, parts, timings)
 #ifdef PARALLEL
    call output_parallel(0, save_step, thisImage, numImages, ntotal_loc, nhalo_loc, nvirt_loc, parts, ntotal)
 #else
-   nhalo_loc = 0
-   bounds_loc(1:dim) = -huge(1._f)
-   bounds_loc(dim + 1:2*dim) = huge(1._f)
-   call generate_virt_part(thisImage, bounds_loc, scale_k, ntotal, ntotal_loc, nhalo_loc, nvirt_loc, parts)
    call output_serial(0, save_step, ntotal, nvirt, parts)
 #endif
 

--- a/src_CAF/single_step_m.f90
+++ b/src_CAF/single_step_m.f90
@@ -27,8 +27,8 @@ contains
 
       allocate (prho(ntotal_loc + nhalo_loc + nvirt_loc))
 
-      drhodt(1:ntotal_loc) = 0._f
-      do i = 1, ntotal_loc
+      drhodt(1:ntotal_loc+nvirt_loc) = 0._f
+      do i = 1, ntotal_loc+nvirt_loc
          dvxdt(1:dim - 1, i) = 0._f
          dvxdt(dim, i) = -g
       end do


### PR DESCRIPTION
Making virtual particles permanent and part of the transfer/halo process, instead of re-adding after the physical/halo particle exchange is complete.

This is a prerequisite to enabling reading particle configurations from input files as reading files during simulation can hinder performance.

What is left to do is to figure out a weighting/load balancing scheme that lets the user choose to load based on compute or memory.