### PR TITLE
Sp hdf5 input

### DIFF
--- a/common/hdf5_parallel_io_helper_m.F90
+++ b/common/hdf5_parallel_io_helper_m.F90
@@ -1,5 +1,5 @@
 module hdf5_parallel_io_helper_m
-   use param, only: f
+   use param, only: f, inputf, outputf
    use hdf5
 #ifdef PARALLEL
    use mpi ! would prefer to use mpi_f08, but hdf5 doesn't play nicely with it
@@ -101,7 +101,7 @@ contains
       character(len=*), intent(in):: dset_name
       integer(HSIZE_T), intent(in):: global_dims ! shape of entire dataset being written
       integer(HSSIZE_T), intent(in):: displ ! displacement of process
-      real(f), intent(in):: ddata(:) ! data local to MPI Process to write
+      real(outputf), intent(in):: ddata(:) ! data local to MPI Process to write
       integer(HSIZE_T):: local_dims(1), global_dims_copy(1), chunk_size(1)
       integer(HSSIZE_T):: displ_copy(1)
       integer, parameter:: rank = 1
@@ -119,7 +119,12 @@ contains
       call h5pset_deflate_f(compress_plist_id, 6, ierr)
 
       ! Creating dataset for entire dataset
-      call h5dcreate_f(gid, dset_name, H5T_NATIVE_DOUBLE, dspace_id, dset_id, ierr, dcpl_id=compress_plist_id)
+      select case (outputf)
+      case (kind(1.))
+         call h5dcreate_f(gid, dset_name, H5T_NATIVE_REAL, dspace_id, dset_id, ierr, dcpl_id=compress_plist_id)
+      case default
+         call h5dcreate_f(gid, dset_name, H5T_NATIVE_DOUBLE, dspace_id, dset_id, ierr, dcpl_id=compress_plist_id)
+      end select
       call h5sclose_f(dspace_id, ierr)
 
       ! Creating dataspace in dataset for each process to write to
@@ -134,8 +139,14 @@ contains
       plist_id = H5P_DEFAULT_F
 #endif
       ! Write the dataset collectively.
-      call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE, ddata, global_dims_copy, ierr, file_space_id=dspace_id, &
-                      mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      select case (outputf)
+      case (kind(1.))
+         call h5dwrite_f(dset_id, H5T_NATIVE_REAL, ddata, global_dims_copy, ierr, file_space_id=dspace_id, &
+                         mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      case default
+         call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE, ddata, global_dims_copy, ierr, file_space_id=dspace_id, &
+                         mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      end select
 
       ! closing all dataspaces,datasets,property lists.
       call h5sclose_f(dspace_id, ierr)
@@ -202,7 +213,7 @@ contains
       character(len=*), intent(in):: dset_name
       integer(HSIZE_T), intent(in):: global_dims(2) ! shape of entire dataset being written
       integer(HSSIZE_T), intent(in):: displ(2) ! displacement of process
-      real(f), intent(in):: ddata(:, :) ! data local to MPI Process to write
+      real(outputf), intent(in):: ddata(:, :) ! data local to MPI Process to write
       integer(HSIZE_T):: local_dims(2), chunk_size(2)
       integer, parameter:: rank = 2
 
@@ -218,7 +229,12 @@ contains
       call h5pset_deflate_f(compress_plist_id, 6, ierr)
 
       ! Creating dataset for entire dataset
-      call h5dcreate_f(gid, dset_name, H5T_NATIVE_DOUBLE, dspace_id, dset_id, ierr, dcpl_id=compress_plist_id)
+      select case (outputf)
+      case (kind(1.))
+         call h5dcreate_f(gid, dset_name, H5T_NATIVE_REAL, dspace_id, dset_id, ierr, dcpl_id=compress_plist_id)
+      case default
+         call h5dcreate_f(gid, dset_name, H5T_NATIVE_DOUBLE, dspace_id, dset_id, ierr, dcpl_id=compress_plist_id)
+      end select
       call h5sclose_f(dspace_id, ierr)
 
       ! Creating dataspace in dataset for each process to write to
@@ -233,8 +249,14 @@ contains
       plist_id = H5P_DEFAULT_F
 #endif
       ! Write the dataset collectively.
-      call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE, ddata, global_dims, ierr, file_space_id=dspace_id, mem_space_id=local_dspace_id, &
-                      xfer_prp=plist_id)
+      select case (outputf)
+      case (kind(1.))
+         call h5dwrite_f(dset_id, H5T_NATIVE_REAL, ddata, global_dims, ierr, file_space_id=dspace_id, &
+                         mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      case default
+         call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE, ddata, global_dims, ierr, file_space_id=dspace_id, &
+                         mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      end select
 
       ! closing all dataspaces,datasets,property lists.
       call h5sclose_f(dspace_id, ierr)

--- a/common/hdf5_parallel_io_helper_m.F90
+++ b/common/hdf5_parallel_io_helper_m.F90
@@ -1,5 +1,5 @@
 module hdf5_parallel_io_helper_m
-   use param, only: f, inputf, outputf
+   use param, only: f
    use hdf5
 #ifdef PARALLEL
    use mpi ! would prefer to use mpi_f08, but hdf5 doesn't play nicely with it
@@ -101,7 +101,7 @@ contains
       character(len=*), intent(in):: dset_name
       integer(HSIZE_T), intent(in):: global_dims ! shape of entire dataset being written
       integer(HSSIZE_T), intent(in):: displ ! displacement of process
-      real(outputf), intent(in):: ddata(:) ! data local to MPI Process to write
+      real(f), intent(in):: ddata(:) ! data local to MPI Process to write
       integer(HSIZE_T):: local_dims(1), global_dims_copy(1), chunk_size(1)
       integer(HSSIZE_T):: displ_copy(1)
       integer, parameter:: rank = 1
@@ -119,7 +119,7 @@ contains
       call h5pset_deflate_f(compress_plist_id, 6, ierr)
 
       ! Creating dataset for entire dataset
-      select case (outputf)
+      select case (f)
       case (kind(1.))
          call h5dcreate_f(gid, dset_name, H5T_NATIVE_REAL, dspace_id, dset_id, ierr, dcpl_id=compress_plist_id)
       case default
@@ -139,7 +139,7 @@ contains
       plist_id = H5P_DEFAULT_F
 #endif
       ! Write the dataset collectively.
-      select case (outputf)
+      select case (f)
       case (kind(1.))
          call h5dwrite_f(dset_id, H5T_NATIVE_REAL, ddata, global_dims_copy, ierr, file_space_id=dspace_id, &
                          mem_space_id=local_dspace_id, xfer_prp=plist_id)
@@ -194,8 +194,14 @@ contains
       plist_id = H5P_DEFAULT_F
 #endif
       ! Write the dataset collectively.
-      call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, ddata, global_dims_copy, ierr, file_space_id=dspace_id, &
-         mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      select case (f)
+      case (kind(1.))
+         call h5dread_f(dset_id, H5T_NATIVE_REAL, ddata, global_dims_copy, ierr, file_space_id=dspace_id, &
+                        mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      case default
+         call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, ddata, global_dims_copy, ierr, file_space_id=dspace_id, &
+                        mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      end select
 
       ! closing all dataspaces,datasets,property lists.
       call h5sclose_f(dspace_id, ierr)
@@ -213,7 +219,7 @@ contains
       character(len=*), intent(in):: dset_name
       integer(HSIZE_T), intent(in):: global_dims(2) ! shape of entire dataset being written
       integer(HSSIZE_T), intent(in):: displ(2) ! displacement of process
-      real(outputf), intent(in):: ddata(:, :) ! data local to MPI Process to write
+      real(f), intent(in):: ddata(:, :) ! data local to MPI Process to write
       integer(HSIZE_T):: local_dims(2), chunk_size(2)
       integer, parameter:: rank = 2
 
@@ -229,7 +235,7 @@ contains
       call h5pset_deflate_f(compress_plist_id, 6, ierr)
 
       ! Creating dataset for entire dataset
-      select case (outputf)
+      select case (f)
       case (kind(1.))
          call h5dcreate_f(gid, dset_name, H5T_NATIVE_REAL, dspace_id, dset_id, ierr, dcpl_id=compress_plist_id)
       case default
@@ -249,7 +255,7 @@ contains
       plist_id = H5P_DEFAULT_F
 #endif
       ! Write the dataset collectively.
-      select case (outputf)
+      select case (f)
       case (kind(1.))
          call h5dwrite_f(dset_id, H5T_NATIVE_REAL, ddata, global_dims, ierr, file_space_id=dspace_id, &
                          mem_space_id=local_dspace_id, xfer_prp=plist_id)
@@ -300,8 +306,14 @@ contains
       plist_id = H5P_DEFAULT_F
 #endif
       ! Write the dataset collectively.
-      call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, ddata, global_dims, ierr, file_space_id=dspace_id, &
-         mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      select case (f)
+      case (kind(1.))
+         call h5dread_f(dset_id, H5T_NATIVE_REAL, ddata, global_dims, ierr, file_space_id=dspace_id, &
+                        mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      case default
+         call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, ddata, global_dims, ierr, file_space_id=dspace_id, &
+                        mem_space_id=local_dspace_id, xfer_prp=plist_id)
+      end select
 
       ! closing all dataspaces,datasets,property lists.
       call h5sclose_f(dspace_id, ierr)

--- a/common/param.f90
+++ b/common/param.f90
@@ -12,7 +12,7 @@ module param
    ! (CUDA's timing subroutines only accept single precision floats)
    ! (Reduction of MPI process' times are hard-coding double precision)
    integer, parameter:: df = kind(1.d0), sf = kind(1.)
-   integer, parameter:: f = df, tf = df
+   integer, parameter:: f = df, tf = df, inputf = df, outputf = sf
 
    ! constants: pi, g (gravity)
    real(f), parameter:: pi = 3.14159265358979323846_f, g = 9.81_f

--- a/common/param.f90
+++ b/common/param.f90
@@ -12,7 +12,7 @@ module param
    ! (CUDA's timing subroutines only accept single precision floats)
    ! (Reduction of MPI process' times are hard-coding double precision)
    integer, parameter:: df = kind(1.d0), sf = kind(1.)
-   integer, parameter:: f = df, tf = df, inputf = df, outputf = sf
+   integer, parameter:: f = sf, tf = df
 
    ! constants: pi, g (gravity)
    real(f), parameter:: pi = 3.14159265358979323846_f, g = 9.81_f
@@ -52,7 +52,7 @@ module param
    integer, parameter:: p1 = 4, p2 = 2
 
    character(*), parameter:: output_directory = "outputdata"
-   character(*), parameter:: input_file = 'example/dambreak.h5'
+   character(*), parameter:: input_file = 'example/sph_out0000.h5' !'example/dambreak.h5'
 
    integer, parameter:: halotype = 100 ! an extra identifier to distinguish halo from real ones
 

--- a/src_CAF/output_m.F90
+++ b/src_CAF/output_m.F90
@@ -6,7 +6,7 @@ module output_m
    use mpi_f08
 #endif
    use hdf5_parallel_io_helper_m, only: hdf5_attribute_write, hdf5_parallel_write, hdf5_fileopen_write
-   use param, only: f, dim, output_directory, halotype
+   use param, only: f, dim, output_directory, halotype, outputf
 
    private
    public:: output
@@ -174,7 +174,7 @@ contains
       type(particles), intent(in):: parts(:)
       integer:: nelem, i
       integer, allocatable:: int_tmp(:, :)
-      real(f), allocatable:: dbl_tmp(:, :)
+      real(outputf), allocatable:: dbl_tmp(:, :)
 
       nelem = size(parts, 1)
       allocate (int_tmp(nelem, 1), dbl_tmp(nelem, 1))

--- a/src_CAF/output_m.F90
+++ b/src_CAF/output_m.F90
@@ -6,7 +6,7 @@ module output_m
    use mpi_f08
 #endif
    use hdf5_parallel_io_helper_m, only: hdf5_attribute_write, hdf5_parallel_write, hdf5_fileopen_write
-   use param, only: f, dim, output_directory, halotype, outputf
+   use param, only: f, dim, output_directory, halotype
 
    private
    public:: output
@@ -174,7 +174,7 @@ contains
       type(particles), intent(in):: parts(:)
       integer:: nelem, i
       integer, allocatable:: int_tmp(:, :)
-      real(outputf), allocatable:: dbl_tmp(:, :)
+      real(f), allocatable:: dbl_tmp(:, :)
 
       nelem = size(parts, 1)
       allocate (int_tmp(nelem, 1), dbl_tmp(nelem, 1))

--- a/src_GPU/input_m.cuf
+++ b/src_GPU/input_m.cuf
@@ -3,7 +3,7 @@ module input_m
    use datatypes, only: particles, interactions
    use hdf5
    use hdf5_parallel_io_helper_m, only: hdf5_fileopen_read, hdf5_attribute_read
-   use param, only: dim, f, dxo, irho, g, gamma, c, hsml, mass, input_file
+   use param, only: dim, f, dxo, irho, g, gamma, c, hsml, mass, input_file, inputf
 
    real(f), parameter:: vnorm(dim, 5) = reshape([-1._f, -1._f, -1._f, &
                                                   1._f,  1._f, -1._f, &

--- a/src_GPU/output_m.cuf
+++ b/src_GPU/output_m.cuf
@@ -91,7 +91,7 @@ contains
       type(particles), intent(in):: parts(:)
       integer:: nelem, i
       integer, allocatable:: int_tmp(:, :)
-      real(outputf), allocatable:: dbl_tmp(:, :)
+      real(f), allocatable:: dbl_tmp(:, :)
 
       nelem = size(parts, 1)
       allocate (int_tmp(nelem, 1), dbl_tmp(nelem, 1))

--- a/src_GPU/output_m.cuf
+++ b/src_GPU/output_m.cuf
@@ -3,7 +3,7 @@ module output_m
    use datatypes, only: particles
    use hdf5
    use hdf5_parallel_io_helper_m, only: hdf5_parallel_write, hdf5_fileopen_write, hdf5_attribute_write
-   use param, only: output_directory, f, dim
+   use param, only: output_directory, f, dim, outputf
 
    private
    public:: output
@@ -91,7 +91,7 @@ contains
       type(particles), intent(in):: parts(:)
       integer:: nelem, i
       integer, allocatable:: int_tmp(:, :)
-      real(f), allocatable:: dbl_tmp(:, :)
+      real(outputf), allocatable:: dbl_tmp(:, :)
 
       nelem = size(parts, 1)
       allocate (int_tmp(nelem, 1), dbl_tmp(nelem, 1))


### PR DESCRIPTION
Enable hdf5 IO to use the right `H5T_NATIVE_REAL/DOUBLE` type that matches the `f` real kind precision in `param.f90`